### PR TITLE
chore: airbnbのeslintをセットアップした

### DIFF
--- a/poboo/.eslintrc
+++ b/poboo/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "airbnb"
+}


### PR DESCRIPTION
# 下準備としてやったことはこんな感じ。

## やったこと (インストール)
* `$ npm info "eslint-config-airbnb@latest" peerDependencies`
  
* 結果  
```
  { eslint: '^4.9.0',
  'eslint-plugin-import': '^2.7.0',
  'eslint-plugin-jsx-a11y': '^6.0.2',
  'eslint-plugin-react': '^7.4.0' }
```  
  
*  `$ npx install-peerdeps --dev eslint-config-airbnb`

* 結果
```
npx: 75個のパッケージを4.867秒でインストールしました。
install-peerdeps v1.6.0
Installing peerdeps for eslint-config-airbnb@16.1.0.
npm install eslint-config-airbnb@16.1.0 eslint@^4.9.0 eslint-plugin-import@^2.7.0 eslint-plugin-jsx-a11y@^6.0.2 eslint-plugin-react@^7.4.0 --save-dev

npm WARN saveError ENOENT: no such file or directory, open '/Users/hiromitsu.ujikawa/package.json'
npm WARN enoent ENOENT: no such file or directory, open '/Users/hiromitsu.ujikawa/package.json'
npm WARN react-native@0.53.3 requires a peer of react@16.2.0 but none is installed. You must install peer dependencies yourself.
npm WARN hiromitsu.ujikawa No description
npm WARN hiromitsu.ujikawa No repository field.
npm WARN hiromitsu.ujikawa No README data
npm WARN hiromitsu.ujikawa No license field.

+ eslint-config-airbnb@16.1.0
+ eslint-plugin-jsx-a11y@6.0.3
+ eslint-plugin-react@7.7.0
+ eslint-plugin-import@2.9.0
+ eslint@4.19.1
added 96 packages in 7.955s
SUCCESS eslint-config-airbnb and its peerDeps were installed successfully.
```